### PR TITLE
Fix alpha patch compatibility for 0.8.2

### DIFF
--- a/st-ligatures-alpha-20200406-28ad288.diff
+++ b/st-ligatures-alpha-20200406-28ad288.diff
@@ -32,7 +32,7 @@ index 0cbb002..76c5c4f 100644
 -       `$(PKG_CONFIG) --cflags freetype2`
 +       `$(PKG_CONFIG) --cflags freetype2` \
 +       `$(PKG_CONFIG) --cflags harfbuzz`
- LIBS = -L$(X11LIB) -lm -lrt -lX11 -lutil -lXft -lXrender \
+ LIBS = -L$(X11LIB) -lm -lrt -lX11 -lutil -lXft -lXrender\
         `$(PKG_CONFIG) --libs fontconfig` \
 -       `$(PKG_CONFIG) --libs freetype2`
 +       `$(PKG_CONFIG) --libs freetype2` \

--- a/st-ligatures-alpha-scrollback-20200406-28ad288.diff
+++ b/st-ligatures-alpha-scrollback-20200406-28ad288.diff
@@ -32,7 +32,7 @@ index 0cbb002..76c5c4f 100644
 -       `$(PKG_CONFIG) --cflags freetype2`
 +       `$(PKG_CONFIG) --cflags freetype2` \
 +       `$(PKG_CONFIG) --cflags harfbuzz`
- LIBS = -L$(X11LIB) -lm -lrt -lX11 -lutil -lXft -lXrender \
+ LIBS = -L$(X11LIB) -lm -lrt -lX11 -lutil -lXft -lXrender\
         `$(PKG_CONFIG) --libs fontconfig` \
 -       `$(PKG_CONFIG) --libs freetype2`
 +       `$(PKG_CONFIG) --libs freetype2` \


### PR DESCRIPTION
As @zeorin pointed out, version `0.8.2` of the `st-alpha` patch is missing expected whitespace, causing the alpha-compatible patches to fail to apply cleanly to `config.mk`. I've updated the patches to apply correctly.

This can be reverted if/when the alpha patch is fixed.

Resolves #8.