### PR TITLE
Fix buffer overflow on hb_shape call

### DIFF
--- a/0.8.4/st-ligatures-20210824-0.8.4.diff
+++ b/0.8.4/st-ligatures-20210824-0.8.4.diff
@@ -1,4 +1,3 @@
-diff --git a/Makefile b/Makefile
 index 470ac86..38240da 100644
 --- a/Makefile
 +++ b/Makefile
@@ -45,7 +44,7 @@ new file mode 100644
 index 0000000..6389e95
 --- /dev/null
 +++ b/hb.c
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,146 @@
 +#include <stdlib.h>
 +#include <stdio.h>
 +#include <math.h>
@@ -69,11 +68,12 @@ index 0000000..6389e95
 +static int hbfontslen = 0;
 +static HbFontMatch *hbfontcache = NULL;
 +
-+/* 
-+ * Replace 0 with a list of font features, wrapped in FEATURE macro, e.g. 
++/*
++ * Poplulate the array with a list of font features, wrapped in FEATURE macro,
++ * e. g.
 + * FEATURE('c', 'a', 'l', 't'), FEATURE('d', 'l', 'i', 'g')
 + */
-+hb_feature_t features[] = { 0 };
++hb_feature_t features[] = { };
 +
 +void
 +hbunloadfonts()
@@ -177,7 +177,7 @@ index 0000000..6389e95
 +	}
 +
 +	/* Shape the segment. */
-+	hb_shape(font, buffer, features, sizeof(features));
++	hb_shape(font, buffer, features, sizeof(features)/sizeof(hb_feature_t));
 +
 +	/* Get new glyph info. */
 +	hb_glyph_info_t *info = hb_buffer_get_glyph_infos(buffer, NULL);

--- a/0.8.4/st-ligatures-alpha-20210824-0.8.4.diff
+++ b/0.8.4/st-ligatures-alpha-20210824-0.8.4.diff
@@ -45,7 +45,7 @@ new file mode 100644
 index 0000000..f9c4f76
 --- /dev/null
 +++ b/hb.c
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,145 @@
 +#include <stdlib.h>
 +#include <stdio.h>
 +#include <math.h>
@@ -69,10 +69,11 @@ index 0000000..f9c4f76
 +static HbFontMatch *hbfontcache = NULL;
 +
 +/*
-+ * Replace 0 with a list of font features, wrapped in FEATURE macro, e.g.
++ * Poplulate the array with a list of font features, wrapped in FEATURE macro,
++ * e. g.
 + * FEATURE('c', 'a', 'l', 't'), FEATURE('d', 'l', 'i', 'g')
 + */
-+hb_feature_t features[] = { 0 };
++hb_feature_t features[] = { };
 +
 +void
 +hbunloadfonts()
@@ -176,7 +177,7 @@ index 0000000..f9c4f76
 +	}
 +
 +	/* Shape the segment. */
-+	hb_shape(font, buffer, features, sizeof(features));
++	hb_shape(font, buffer, features, sizeof(features)/sizeof(hb_feature_t));
 +
 +	/* Get new glyph info. */
 +	hb_glyph_info_t *info = hb_buffer_get_glyph_infos(buffer, NULL);

--- a/0.8.4/st-ligatures-alpha-scrollback-20210824-0.8.4.diff
+++ b/0.8.4/st-ligatures-alpha-scrollback-20210824-0.8.4.diff
@@ -45,7 +45,7 @@ new file mode 100644
 index 0000000..f9c4f76
 --- /dev/null
 +++ b/hb.c
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,145 @@
 +#include <stdlib.h>
 +#include <stdio.h>
 +#include <math.h>
@@ -69,10 +69,11 @@ index 0000000..f9c4f76
 +static HbFontMatch *hbfontcache = NULL;
 +
 +/*
-+ * Replace 0 with a list of font features, wrapped in FEATURE macro, e.g.
++ * Poplulate the array with a list of font features, wrapped in FEATURE macro,
++ * e. g.
 + * FEATURE('c', 'a', 'l', 't'), FEATURE('d', 'l', 'i', 'g')
 + */
-+hb_feature_t features[] = { 0 };
++hb_feature_t features[] = { };
 +
 +void
 +hbunloadfonts()
@@ -176,7 +177,7 @@ index 0000000..f9c4f76
 +	}
 +
 +	/* Shape the segment. */
-+	hb_shape(font, buffer, features, sizeof(features));
++	hb_shape(font, buffer, features, sizeof(features)/sizeof(hb_feature_t));
 +
 +	/* Get new glyph info. */
 +	hb_glyph_info_t *info = hb_buffer_get_glyph_infos(buffer, NULL);

--- a/0.8.4/st-ligatures-boxdraw-20210824-0.8.4.diff
+++ b/0.8.4/st-ligatures-boxdraw-20210824-0.8.4.diff
@@ -45,7 +45,7 @@ new file mode 100644
 index 0000000..a47300e
 --- /dev/null
 +++ b/hb.c
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,149 @@
 +#include <stdlib.h>
 +#include <stdio.h>
 +#include <math.h>
@@ -69,10 +69,11 @@ index 0000000..a47300e
 +static HbFontMatch *hbfontcache = NULL;
 +
 +/*
-+ * Replace 0 with a list of font features, wrapped in FEATURE macro, e.g.
++ * Poplulate the array with a list of font features, wrapped in FEATURE macro,
++ * e. g.
 + * FEATURE('c', 'a', 'l', 't'), FEATURE('d', 'l', 'i', 'g')
 + */
-+hb_feature_t features[] = { 0 };
++hb_feature_t features[] = { };
 +
 +void
 +hbunloadfonts()
@@ -180,7 +181,7 @@ index 0000000..a47300e
 +	}
 +
 +	/* Shape the segment. */
-+	hb_shape(font, buffer, features, sizeof(features));
++	hb_shape(font, buffer, features, sizeof(features)/sizeof(hb_feature_t));
 +
 +	/* Get new glyph info. */
 +	hb_glyph_info_t *info = hb_buffer_get_glyph_infos(buffer, NULL);

--- a/0.8.4/st-ligatures-scrollback-20210824-0.8.4.diff
+++ b/0.8.4/st-ligatures-scrollback-20210824-0.8.4.diff
@@ -45,7 +45,7 @@ new file mode 100644
 index 0000000..f9c4f76
 --- /dev/null
 +++ b/hb.c
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,145 @@
 +#include <stdlib.h>
 +#include <stdio.h>
 +#include <math.h>
@@ -69,10 +69,11 @@ index 0000000..f9c4f76
 +static HbFontMatch *hbfontcache = NULL;
 +
 +/*
-+ * Replace 0 with a list of font features, wrapped in FEATURE macro, e.g.
++ * Poplulate the array with a list of font features, wrapped in FEATURE macro,
++ * e. g.
 + * FEATURE('c', 'a', 'l', 't'), FEATURE('d', 'l', 'i', 'g')
 + */
-+hb_feature_t features[] = { 0 };
++hb_feature_t features[] = { };
 +
 +void
 +hbunloadfonts()
@@ -176,7 +177,7 @@ index 0000000..f9c4f76
 +	}
 +
 +	/* Shape the segment. */
-+	hb_shape(font, buffer, features, sizeof(features));
++	hb_shape(font, buffer, features, sizeof(features)/sizeof(hb_feature_t));
 +
 +	/* Get new glyph info. */
 +	hb_glyph_info_t *info = hb_buffer_get_glyph_infos(buffer, NULL);


### PR DESCRIPTION
Fix #19: potential buffer overflow on calculating `features` array size.