### PR TITLE
Workaround the delete character not resetting ATTR_WRAP attribute.

### DIFF
--- a/0.9/st-ligatures-20230105-0.9.diff
+++ b/0.9/st-ligatures-20230105-0.9.diff
@@ -312,13 +312,14 @@ index 2a3bd38..9b97075 100644
 +	HbTransformData shaped = { 0 };
 +
 +	/* Initial values. */
-+	mode = prevmode = glyphs[0].mode;
++	mode = prevmode = glyphs[0].mode & ~ATTR_WRAP;
 +	xresetfontsettings(mode, &font, &frcflags);
  
  	for (i = 0, xp = winx, yp = winy + font->ascent; i < len; ++i) {
 -		/* Fetch rune and mode for current glyph. */
 -		rune = glyphs[i].u;
- 		mode = glyphs[i].mode;
+-		mode = glyphs[i].mode;
++		mode = glyphs[i].mode & ~ATTR_WRAP;
  
  		/* Skip dummy wide-character spacing. */
 -		if (mode == ATTR_WDUMMY)

--- a/0.9/st-ligatures-alpha-20230105-0.9.diff
+++ b/0.9/st-ligatures-alpha-20230105-0.9.diff
@@ -313,13 +313,14 @@ index 27e81d1..9d84793 100644
 +	HbTransformData shaped = { 0 };
 +
 +	/* Initial values. */
-+	mode = prevmode = glyphs[0].mode;
++	mode = prevmode = glyphs[0].mode & ~ATTR_WRAP;
 +	xresetfontsettings(mode, &font, &frcflags);
  
  	for (i = 0, xp = winx, yp = winy + font->ascent; i < len; ++i) {
 -		/* Fetch rune and mode for current glyph. */
 -		rune = glyphs[i].u;
- 		mode = glyphs[i].mode;
+-		mode = glyphs[i].mode;
++		mode = glyphs[i].mode & ~ATTR_WRAP;
  
  		/* Skip dummy wide-character spacing. */
 -		if (mode == ATTR_WDUMMY)

--- a/0.9/st-ligatures-alpha-scrollback-20230105-0.9.diff
+++ b/0.9/st-ligatures-alpha-scrollback-20230105-0.9.diff
@@ -314,13 +314,14 @@ index 27e81d1..5d19ed7 100644
 +	HbTransformData shaped = { 0 };
 +
 +	/* Initial values. */
-+	mode = prevmode = glyphs[0].mode;
++	mode = prevmode = glyphs[0].mode & ~ATTR_WRAP;
 +	xresetfontsettings(mode, &font, &frcflags);
  
  	for (i = 0, xp = winx, yp = winy + font->ascent; i < len; ++i) {
 -		/* Fetch rune and mode for current glyph. */
 -		rune = glyphs[i].u;
- 		mode = glyphs[i].mode;
+-		mode = glyphs[i].mode;
++		mode = glyphs[i].mode & ~ATTR_WRAP;
  
  		/* Skip dummy wide-character spacing. */
 -		if (mode == ATTR_WDUMMY)

--- a/0.9/st-ligatures-alpha-scrollback-ringbuffer-20230105-0.9.diff
+++ b/0.9/st-ligatures-alpha-scrollback-ringbuffer-20230105-0.9.diff
@@ -314,13 +314,14 @@ index 27e81d1..5d19ed7 100644
 +	HbTransformData shaped = { 0 };
 +
 +	/* Initial values. */
-+	mode = prevmode = glyphs[0].mode;
++	mode = prevmode = glyphs[0].mode & ~ATTR_WRAP;
 +	xresetfontsettings(mode, &font, &frcflags);
  
  	for (i = 0, xp = winx, yp = winy + font->ascent; i < len; ++i) {
 -		/* Fetch rune and mode for current glyph. */
 -		rune = glyphs[i].u;
- 		mode = glyphs[i].mode;
+-		mode = glyphs[i].mode;
++		mode = glyphs[i].mode & ~ATTR_WRAP;
  
  		/* Skip dummy wide-character spacing. */
 -		if (mode == ATTR_WDUMMY)

--- a/0.9/st-ligatures-boxdraw-20230105-0.9.diff
+++ b/0.9/st-ligatures-boxdraw-20230105-0.9.diff
@@ -313,13 +313,14 @@ index bf6bbf9..929a59a 100644
 +	HbTransformData shaped = { 0 };
 +
 +	/* Initial values. */
-+	mode = prevmode = glyphs[0].mode;
++	mode = prevmode = glyphs[0].mode & ~ATTR_WRAP;
 +	xresetfontsettings(mode, &font, &frcflags);
  
  	for (i = 0, xp = winx, yp = winy + font->ascent; i < len; ++i) {
 -		/* Fetch rune and mode for current glyph. */
 -		rune = glyphs[i].u;
- 		mode = glyphs[i].mode;
+-		mode = glyphs[i].mode;
++		mode = glyphs[i].mode & ~ATTR_WRAP;
  
  		/* Skip dummy wide-character spacing. */
 -		if (mode == ATTR_WDUMMY)

--- a/0.9/st-ligatures-scrollback-20230105-0.9.diff
+++ b/0.9/st-ligatures-scrollback-20230105-0.9.diff
@@ -312,13 +312,14 @@ index 2a3bd38..e66cf0c 100644
 +	HbTransformData shaped = { 0 };
 +
 +	/* Initial values. */
-+	mode = prevmode = glyphs[0].mode;
++	mode = prevmode = glyphs[0].mode & ~ATTR_WRAP;
 +	xresetfontsettings(mode, &font, &frcflags);
  
  	for (i = 0, xp = winx, yp = winy + font->ascent; i < len; ++i) {
 -		/* Fetch rune and mode for current glyph. */
 -		rune = glyphs[i].u;
- 		mode = glyphs[i].mode;
+-		mode = glyphs[i].mode;
++		mode = glyphs[i].mode & ~ATTR_WRAP;
  
  		/* Skip dummy wide-character spacing. */
 -		if (mode == ATTR_WDUMMY)

--- a/0.9/st-ligatures-scrollback-ringbuffer-20230105-0.9.diff
+++ b/0.9/st-ligatures-scrollback-ringbuffer-20230105-0.9.diff
@@ -312,13 +312,14 @@ index 9891e91..ec3567a 100644
 +	HbTransformData shaped = { 0 };
 +
 +	/* Initial values. */
-+	mode = prevmode = glyphs[0].mode;
++	mode = prevmode = glyphs[0].mode & ~ATTR_WRAP;
 +	xresetfontsettings(mode, &font, &frcflags);
  
  	for (i = 0, xp = winx, yp = winy + font->ascent; i < len; ++i) {
 -		/* Fetch rune and mode for current glyph. */
 -		rune = glyphs[i].u;
- 		mode = glyphs[i].mode;
+-		mode = glyphs[i].mode;
++		mode = glyphs[i].mode & ~ATTR_WRAP;
  
  		/* Skip dummy wide-character spacing. */
 -		if (mode == ATTR_WDUMMY)


### PR DESCRIPTION
A fix to handle extra ATTR_WRAP attributes in a line after deleting a character. Reported in #32 