### PR TITLE
Fix boxdraw indexes

### DIFF
--- a/0.9/st-ligatures-boxdraw-20230105-0.9.diff
+++ b/0.9/st-ligatures-boxdraw-20230105-0.9.diff
@@ -403,10 +403,10 @@ index bf6bbf9..929a59a 100644
 +					runewidth = win.cw * ((glyphs[start + idx].mode & ATTR_WIDE) ? 2.0f : 1.0f);
 +				}
 +
-+				if (glyphs[start + code_idx].mode & ATTR_BOXDRAW) {
++				if (glyphs[start + idx].mode & ATTR_BOXDRAW) {
 +					/* minor shoehorning: boxdraw uses only this ushort */
 +					specs[numspecs].font = font->match;
-+					specs[numspecs].glyph = boxdrawindex(&glyphs[start + code_idx]);
++					specs[numspecs].glyph = boxdrawindex(&glyphs[start + idx]);
 +					specs[numspecs].x = xp;
 +					specs[numspecs].y = yp;
 +					numspecs++;


### PR DESCRIPTION
It took me a couple of hours to figure out why some characters were behaving oddly on my terminal, and it turned out that two index bugs in `st-ligatures-boxdraw-20230105-0.9.diff` were causing all the problems.

Before:
![before](https://github.com/cog1to/st-ligatures/assets/106755522/0802dfa8-0507-4ed1-b365-3459b86446cd)

After:
![after](https://github.com/cog1to/st-ligatures/assets/106755522/85df3562-9670-43ff-9490-10f287bf5539)

Edit: this can be reproduced with JetBrainsMono Nerd Font as it uses two glyphs for `ὼ` character.